### PR TITLE
Allow Clone for ArcadeInput

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ impl Plugin for RustArcadePlugin {
 }
 
 // Inputs on the arcade machine
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ArcadeInput {
     JoyUp,
     JoyDown,


### PR DESCRIPTION
This would help create debug mappings, such as https://github.com/Vrixyz/simon/blob/006e9e55de25ea90429494eb18b6b710551f6a72/src/fake_arcade.rs#L48